### PR TITLE
Added core fileset to the default target

### DIFF
--- a/subservient.core
+++ b/subservient.core
@@ -21,6 +21,7 @@ filesets:
   openlane:
     files:
       - data/params.tcl : {file_type : tclSource}
+
   tb:
     files:
       - tb/uart_decoder.v
@@ -36,7 +37,7 @@ filesets:
 
 targets:
   default:
-    filesets : [soc]
+    filesets : [soc, core]
 
   lint:
     default_tool : verilator


### PR DESCRIPTION
As I think it is likely needed by cores depending on subservient, as is the case for my subservient_wrapped.